### PR TITLE
Refactor AscendMMEncoderAttention for better sequence handling

### DIFF
--- a/tests/e2e/pull_request/two_card/golden/qwen3_6_27b_image_tp2.json
+++ b/tests/e2e/pull_request/two_card/golden/qwen3_6_27b_image_tp2.json
@@ -1,0 +1,17 @@
+[
+  {
+    "_placeholder": true,
+    "prompt": "Record on NPU: see docs/plans/aclgraph-vit-01-stage1-fia.md section 6.2.4",
+    "token_ids": []
+  },
+  {
+    "_placeholder": true,
+    "prompt": "Record on NPU: see docs/plans/aclgraph-vit-01-stage1-fia.md section 6.2.4",
+    "token_ids": []
+  },
+  {
+    "_placeholder": true,
+    "prompt": "Record on NPU: see docs/plans/aclgraph-vit-01-stage1-fia.md section 6.2.4",
+    "token_ids": []
+  }
+]

--- a/tests/e2e/pull_request/two_card/test_qwen3_6_27b_fia.py
+++ b/tests/e2e/pull_request/two_card/test_qwen3_6_27b_fia.py
@@ -1,0 +1,138 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stage 1 E2E for Qwen/Qwen3.6-27B after ViT FIA op replacement."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+from vllm.assets.image import ImageAsset
+
+from tests.e2e.conftest import VllmRunner
+
+GOLDEN_PATH = Path(__file__).parent / "golden" / "qwen3_6_27b_image_tp2.json"
+MODEL = "Qwen/Qwen3.6-27B"
+
+
+def _qwen3_vl_prompt(question: str) -> str:
+    placeholder = "<|image_pad|>"
+    return (
+        "<|im_start|>system\nYou are a helpful assistant.\n"
+        f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+        f"{question}\n"
+        f"<|im_start|>assistant\n"
+    )
+
+
+def _load_golden():
+    assert GOLDEN_PATH.exists(), (
+        f"Golden fixture missing: {GOLDEN_PATH}. "
+        "Generate it on NPU hardware per docs/plans/aclgraph-vit-01-stage1-fia.md §6.2.4."
+    )
+    with GOLDEN_PATH.open(encoding="utf-8") as fp:
+        golden = json.load(fp)
+    if golden and golden[0].get("_placeholder"):
+        pytest.skip(
+            "Golden fixture is a placeholder; record real token_ids on NPU "
+            "(see docs/plans/aclgraph-vit-01-stage1-fia.md §6.2.4)."
+        )
+    return golden
+
+
+@patch.dict(os.environ, {"VLLM_WORKER_MULTIPROC_METHOD": "spawn"})
+def test_qwen3_6_27b_image_fia_accuracy_tp2():
+    image = ImageAsset("cherry_blossom").pil_image.convert("RGB")
+    questions = [
+        "What is the content of this image?",
+        "Describe the dominant color of this image in one word.",
+        "Is there any text in this image?",
+    ]
+    prompts = [_qwen3_vl_prompt(q) for q in questions]
+    images = [image] * len(prompts)
+
+    with VllmRunner(
+        MODEL,
+        tensor_parallel_size=2,
+        dtype="bfloat16",
+        max_model_len=8192,
+        gpu_memory_utilization=0.85,
+        cudagraph_capture_sizes=[1, 2, 4, 8],
+        limit_mm_per_prompt={"image": 1},
+        mm_processor_kwargs={
+            "min_pixels": 28 * 28,
+            "max_pixels": 1280 * 28 * 28,
+            "fps": 1,
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(
+            prompts=prompts,
+            images=images,
+            max_tokens=64,
+        )
+
+    assert len(outputs) == len(prompts)
+    for _token_ids, text in outputs:
+        assert text, "Generated output should not be empty."
+
+    golden = _load_golden()
+    assert len(golden) == len(outputs)
+    for i, ((tok_ids, _), exp) in enumerate(zip(outputs, golden)):
+        exp_ids = exp["token_ids"]
+        compare_len = min(len(tok_ids), len(exp_ids))
+        matched = sum(1 for j in range(compare_len) if tok_ids[j] == exp_ids[j])
+        ratio = matched / max(compare_len, 1)
+        assert ratio >= 0.99, (
+            f"prompt[{i}] top-1 agreement {ratio:.4f} < 0.99 (matched {matched}/{compare_len})"
+        )
+
+
+@patch.dict(os.environ, {"VLLM_WORKER_MULTIPROC_METHOD": "spawn"})
+def test_qwen3_6_27b_video_fia_smoke_tp2():
+    fake_frames = [
+        Image.new("RGB", (224, 224), color=(r, g, b))
+        for (r, g, b) in [(255, 0, 0), (0, 255, 0), (0, 0, 255), (200, 200, 200)]
+    ]
+    question = "Describe what happens in this video."
+    prompt = (
+        "<|im_start|>system\nYou are a helpful assistant.\n"
+        "<|im_start|>user\n<|vision_start|><|video_pad|><|vision_end|>"
+        f"{question}\n"
+        "<|im_start|>assistant\n"
+    )
+    whitelist = ["video", "color", "frame", "red", "green", "blue", "white", "gray", "image"]
+
+    with VllmRunner(
+        MODEL,
+        tensor_parallel_size=2,
+        dtype="bfloat16",
+        max_model_len=8192,
+        gpu_memory_utilization=0.85,
+        limit_mm_per_prompt={"video": 1},
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(
+            prompts=[prompt],
+            videos=[fake_frames],
+            max_tokens=64,
+        )
+
+    assert len(outputs) == 1
+    _, text = outputs[0]
+    assert text, "Generated output should not be empty."
+    text_lc = text.lower()
+    assert any(k in text_lc for k in whitelist), f"video smoke output lacks whitelist token: {text!r}"

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -1,0 +1,318 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for AscendMMEncoderAttention after Stage 1 FIA op replacement."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+# Avoid pulling in vllm / torch_npu on CI without full stack.
+if "torch_npu" not in sys.modules:
+    sys.modules["torch_npu"] = types.ModuleType("torch_npu")
+
+_vllm_mm_encoder = types.ModuleType("vllm.model_executor.layers.attention.mm_encoder_attention")
+
+
+class _MMEncoderAttention:
+    pass
+
+
+_vllm_mm_encoder.MMEncoderAttention = _MMEncoderAttention
+sys.modules["vllm.model_executor.layers.attention.mm_encoder_attention"] = _vllm_mm_encoder
+
+_vllm_registry = types.ModuleType("vllm.v1.attention.backends.registry")
+
+
+class _AttentionBackendEnum:
+    pass
+
+
+_vllm_registry.AttentionBackendEnum = _AttentionBackendEnum
+sys.modules["vllm.v1.attention.backends.registry"] = _vllm_registry
+
+_MM_ENCODER_ATTENTION_PATH = (
+    Path(__file__).resolve().parents[3] / "vllm_ascend" / "ops" / "mm_encoder_attention.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "vllm_ascend.ops.mm_encoder_attention",
+    _MM_ENCODER_ATTENTION_PATH,
+)
+_mm_encoder_attention = importlib.util.module_from_spec(_spec)
+sys.modules["vllm_ascend.ops.mm_encoder_attention"] = _mm_encoder_attention
+_spec.loader.exec_module(_mm_encoder_attention)
+
+AscendMMEncoderAttention = _mm_encoder_attention.AscendMMEncoderAttention
+MAX_PAD_SIZE = _mm_encoder_attention.MAX_PAD_SIZE
+SWA_INT_MAX = _mm_encoder_attention.SWA_INT_MAX
+FIA_BLOCK_SIZE = _mm_encoder_attention.FIA_BLOCK_SIZE
+
+
+def _make_layer(num_heads=4, num_kv_heads=4, head_size=72):
+    layer = AscendMMEncoderAttention.__new__(AscendMMEncoderAttention)
+    layer.num_heads = num_heads
+    layer.num_kv_heads = num_kv_heads
+    layer.num_queries_per_kv = num_heads // num_kv_heads
+    layer.head_size = head_size
+    layer.enable_pad = 64 < head_size < 128
+    layer.scale_value = head_size**-0.5
+    return layer
+
+
+def _ref_attention(query, key, value, seq_lens):
+    """CPU fp32 reference. Inputs [B, S, H, D]; seq_lens: per-sample valid length."""
+    bsz, _, num_heads, head_dim = query.shape
+    out = torch.zeros_like(query, dtype=torch.float32)
+    scale = head_dim**-0.5
+    for b in range(bsz):
+        s = seq_lens[b]
+        q_b = query[b, :s].permute(1, 0, 2).to(torch.float32)
+        k_b = key[b, :s].permute(1, 0, 2).to(torch.float32)
+        v_b = value[b, :s].permute(1, 0, 2).to(torch.float32)
+        out_b = F.scaled_dot_product_attention(
+            q_b.unsqueeze(0),
+            k_b.unsqueeze(0),
+            v_b.unsqueeze(0),
+            scale=scale,
+            dropout_p=0.0,
+            is_causal=False,
+        ).squeeze(0)
+        out[b, :s] = out_b.permute(1, 0, 2).to(query.dtype)
+    return out
+
+
+def _compute_fia_output(query, key, value, actual_seq_lengths, scale):
+    """Emulate functional FIA by segment-wise CPU SDPA."""
+    output = torch.zeros_like(query)
+    starts = [0] + list(actual_seq_lengths[:-1])
+    for i, end in enumerate(actual_seq_lengths):
+        beg = starts[i]
+        if end <= beg:
+            continue
+        q_seg = query[beg:end].permute(1, 0, 2).to(torch.float32)
+        k_seg = key[beg:end].permute(1, 0, 2).to(torch.float32)
+        v_seg = value[beg:end].permute(1, 0, 2).to(torch.float32)
+        attn = F.scaled_dot_product_attention(
+            q_seg.unsqueeze(0),
+            k_seg.unsqueeze(0),
+            v_seg.unsqueeze(0),
+            scale=scale,
+            dropout_p=0.0,
+            is_causal=False,
+        ).squeeze(0)
+        output[beg:end] = attn.permute(1, 0, 2).to(query.dtype)
+    return output
+
+
+@pytest.fixture
+def fake_fia():
+    captured = {}
+
+    def fake_fia(
+        *,
+        query,
+        key,
+        value,
+        atten_mask,
+        block_table,
+        input_layout,
+        block_size,
+        actual_seq_lengths,
+        actual_seq_lengths_kv,
+        num_key_value_heads,
+        num_heads,
+        scale,
+        sparse_mode,
+        pre_tokens=None,
+        next_tokens=None,
+    ):
+        captured["q_shape"] = query.shape
+        captured["k_shape"] = key.shape
+        captured["v_shape"] = value.shape
+        captured["input_layout"] = input_layout
+        captured["block_size"] = block_size
+        captured["actual_seq_lengths"] = actual_seq_lengths
+        captured["actual_seq_lengths_kv"] = actual_seq_lengths_kv
+        captured["num_heads"] = num_heads
+        captured["num_key_value_heads"] = num_key_value_heads
+        captured["scale"] = scale
+        captured["sparse_mode"] = sparse_mode
+        captured["block_table"] = block_table
+        captured["atten_mask"] = atten_mask
+        captured["pre_tokens"] = pre_tokens
+        captured["next_tokens"] = next_tokens
+        output = _compute_fia_output(query, key, value, actual_seq_lengths, scale)
+        return output, None
+
+    _mm_encoder_attention.torch_npu.npu_fused_infer_attention_score = fake_fia
+    yield captured
+    if hasattr(_mm_encoder_attention.torch_npu, "npu_fused_infer_attention_score"):
+        delattr(_mm_encoder_attention.torch_npu, "npu_fused_infer_attention_score")
+
+
+def test_shape_basic(fake_fia):
+    layer = _make_layer(num_heads=4, num_kv_heads=4, head_size=128)
+    bsz, q_len = 2, 4
+    query = torch.randn(bsz, q_len, layer.num_heads * layer.head_size)
+    key = query.clone()
+    value = query.clone()
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert out.shape == (bsz, q_len, layer.num_heads * layer.head_size)
+    assert fake_fia["input_layout"] == "TND"
+    assert fake_fia["sparse_mode"] == 0
+    assert fake_fia["block_size"] == FIA_BLOCK_SIZE
+
+
+def test_shape_4d_output(fake_fia):
+    layer = _make_layer(num_heads=4, num_kv_heads=4, head_size=128)
+    bsz, q_len = 2, 4
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert out.shape == query.shape
+
+
+def test_head_dim_pad(fake_fia):
+    layer = _make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+    bsz, q_len = 2, 4
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert fake_fia["q_shape"] == (bsz * q_len, 4, MAX_PAD_SIZE)
+    assert out.shape == query.shape
+
+
+def test_variable_seqlens(fake_fia):
+    layer = _make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+    seq_lens = [3, 7, 2]
+    cu_seqlens = torch.tensor([0, 3, 10, 12], dtype=torch.int32, device="cpu")
+    max_q_len = max(seq_lens)
+    torch.manual_seed(0)
+    query = torch.randn(len(seq_lens), max_q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+
+    out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert out.shape == query.shape
+    assert fake_fia["actual_seq_lengths"] == [3, 10, 12]
+    assert fake_fia["actual_seq_lengths_kv"] == [3, 10, 12]
+    assert fake_fia["q_shape"] == (len(seq_lens) * max_q_len, 4, MAX_PAD_SIZE)
+
+
+def test_precomputed_sequence_lengths(fake_fia):
+    layer = _make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+    seq_lens = [3, 7, 2]
+    sequence_lengths = torch.tensor(seq_lens, dtype=torch.int64, device="cpu")
+    max_q_len = max(seq_lens)
+    query = torch.randn(len(seq_lens), max_q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seqlens = torch.tensor([0, 3, 10, 12], dtype=torch.int32, device="cpu")
+
+    out = layer.forward_oot(
+        query,
+        key,
+        value,
+        cu_seqlens=cu_seqlens,
+        sequence_lengths=sequence_lengths,
+    )
+
+    assert fake_fia["actual_seq_lengths"] == [3, 10, 12]
+    assert out.shape == query.shape
+
+
+def test_mqa_gqa_repeat(fake_fia):
+    layer = _make_layer(num_heads=8, num_kv_heads=2, head_size=72)
+    bsz, q_len = 2, 4
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size, dtype=torch.bfloat16)
+    key = torch.randn(bsz, q_len, layer.num_kv_heads, layer.head_size, dtype=torch.bfloat16)
+    value = torch.randn_like(key)
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert fake_fia["k_shape"][1] == layer.num_heads
+    assert fake_fia["v_shape"][1] == layer.num_heads
+    assert fake_fia["num_heads"] == 8
+    assert fake_fia["num_key_value_heads"] == 2
+
+
+def test_get_vit_fia_params_dense_constants():
+    layer = _make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+    bsz, q_len = 2, 4
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    params = layer._get_vit_fia_params(bsz, q_len, cu_seqlens, None)
+
+    assert params[0] == [4, 8]
+    assert params[1] == [4, 8]
+    assert params[2] == FIA_BLOCK_SIZE
+    assert params[3] is None
+    assert params[4] == "TND"
+    assert params[5] == 0
+    assert params[6] is None
+    assert params[7] == SWA_INT_MAX
+    assert params[8] == SWA_INT_MAX
+
+
+def test_fia_call_args(fake_fia):
+    layer = _make_layer(num_heads=16, num_kv_heads=16, head_size=72)
+    bsz, q_len = 4, 4
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert fake_fia["input_layout"] == "TND"
+    assert fake_fia["sparse_mode"] == 0
+    assert fake_fia["block_size"] == FIA_BLOCK_SIZE
+    assert fake_fia["block_table"] is None
+    assert fake_fia["atten_mask"] is None
+    assert fake_fia["pre_tokens"] == SWA_INT_MAX
+    assert fake_fia["next_tokens"] == SWA_INT_MAX
+    assert fake_fia["actual_seq_lengths"] == [4, 8, 12, 16]
+    assert fake_fia["scale"] == pytest.approx(layer.scale_value)
+
+
+def test_dtype_bf16(fake_fia):
+    layer = _make_layer(num_heads=16, num_kv_heads=16, head_size=72)
+    bsz, q_len = 2, 4
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+    out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+    assert out.dtype == torch.bfloat16

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -19,23 +19,14 @@ import einops
 import numpy as np
 import torch
 import torch.nn.functional as F
+import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from vllm_ascend.device.device_op import DeviceOperator
-
 MIN_PAD_SIZE: int = 64  # min_size to pad weight
 MAX_PAD_SIZE: int = 128  # max_size to pad weight
-
-# Use seq_lens CPU cache to avoid frequent d2h copy.
-# AscendMMEncoderAttention will copy the cu_seqlens from NPU to CPU in every
-# forward, since the op _npu_flash_attention_unpad() requires CPU cu_seqlens
-# (otherwise it will break down).
-# Thus, we use seq_lens_cpu_cache to cache this tensor, since it's shared
-# between all layers, but may change in different forward step. When the
-# current layer_index is 0, we update the cache, otherwise we directly use the
-# cache to avoid frequent diff and copy operations, which are costful.
-seq_lens_cpu_cache: torch.Tensor = None
+SWA_INT_MAX: int = 2147483647
+FIA_BLOCK_SIZE: int = 128
 
 
 class AscendMMEncoderAttention(MMEncoderAttention):
@@ -75,6 +66,12 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         cu_seqlens: np.ndarray,
         device: torch.device,
     ) -> np.ndarray | None:
+        """Upstream contract helper for ``prepare_encoder_metadata``.
+
+        Returns per-sequence lengths on CPU. FIA uses cumulative
+        ``actual_seq_lengths`` computed in ``forward_oot`` via
+        ``_get_vit_fia_params``.
+        """
         if cu_seqlens is None:
             return None
 
@@ -114,6 +111,8 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         cu_seqlens: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if cu_seqlens is not None:
+            if cu_seqlens.device.type != "cpu":
+                cu_seqlens = cu_seqlens.to("cpu")
             return cu_seqlens
 
         # If cu_seqlens is not provided, we create a default one assuming all sequences have the same length.
@@ -122,53 +121,131 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
         return cu_seqlens
 
+    def _maybe_compute_actual_seq_lengths(
+        self,
+        bsz: int,
+        q_len: int,
+        cu_seqlens: torch.Tensor | None,
+        sequence_lengths: torch.Tensor | None,
+    ) -> tuple[list[int], list[int]]:
+        """Build FIA ``actual_seq_lengths`` as cumulative host-side ``list[int]``."""
+        if sequence_lengths is not None:
+            seq_lens_cpu = sequence_lengths
+            if seq_lens_cpu.device.type != "cpu":
+                seq_lens_cpu = seq_lens_cpu.to("cpu")
+            actual = seq_lens_cpu.cumsum(0).to(torch.int64).tolist()
+        else:
+            cu = self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens)
+            actual = cu[1:].to(torch.int64).tolist()
+
+        return actual, actual
+
+    def _get_vit_fia_params(
+        self,
+        bsz: int,
+        q_len: int,
+        cu_seqlens: torch.Tensor | None,
+        sequence_lengths: torch.Tensor | None,
+    ) -> tuple[
+        list[int],
+        list[int],
+        int,
+        torch.Tensor | None,
+        str,
+        int,
+        torch.Tensor | None,
+        int,
+        int,
+    ]:
+        """Build FIA inputs for dense ViT (PrefillNoCache + non-causal).
+
+        Stage 1 uses fixed dense constants; Stage 2 capture/replay will reuse
+        this helper as the single source of FIA metadata.
+        """
+        actual_seq_lengths, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(
+            bsz, q_len, cu_seqlens, sequence_lengths
+        )
+        return (
+            actual_seq_lengths,
+            actual_seq_lengths_kv,
+            FIA_BLOCK_SIZE,
+            None,
+            "TND",
+            0,
+            None,
+            SWA_INT_MAX,
+            SWA_INT_MAX,
+        )
+
     def forward_oot(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        max_seqlen: torch.Tensor | None = None,  # kept for upstream sig parity
+        sequence_lengths: torch.Tensor | None = None,
+    ):
+        return self._forward_eager_fia(
+            query, key, value, cu_seqlens, max_seqlen, sequence_lengths
+        )
+
+    def _forward_eager_fia(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
         sequence_lengths: torch.Tensor | None = None,
     ):
         bsz, q_len = query.size()[:2]
         kv_len = key.size(1)
         is_reshaped = query.dim() == 4
 
-        if sequence_lengths is not None:
-            # Use pre-compute seq_lens before vision blocks.
-            if sequence_lengths.device.type != "cpu":
-                sequence_lengths = sequence_lengths.to("cpu")
-            seq_lens_cpu = sequence_lengths
-        else:
-            # Convert cu_seqlens to seq_lens and move it to CPU, since FA requires CPU seq_lens.
-            # NOTE: This will considerably hurt performance.
-            cu_seqlens = self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens)
-            seq_lens_cpu = torch.diff(cu_seqlens).to("cpu")
+        (
+            actual_seq_lengths,
+            actual_seq_lengths_kv,
+            block_size,
+            block_table,
+            input_layout,
+            sparse_mode,
+            attn_mask,
+            pre_tokens,
+            next_tokens,
+        ) = self._get_vit_fia_params(bsz, q_len, cu_seqlens, sequence_lengths)
 
         # q, k, v: [b, s, head, head_dim] -> [b * s, head, head_dim]
         q, k, v = self._reshape_qkv_to_3d(query, key, value, bsz, q_len, kv_len)
 
+        origin_head_dim = q.shape[-1]
         if self.enable_pad:
-            origin_shape = q.shape[-1]
-            pad_len = MAX_PAD_SIZE - origin_shape
+            pad_len = MAX_PAD_SIZE - origin_head_dim
             # [b * s, head, head_dim] -> [b * s, head, MAX_PAD_SIZE]
             q = F.pad(q, (0, pad_len), mode="constant", value=0)
             k = F.pad(k, (0, pad_len), mode="constant", value=0)
             v = F.pad(v, (0, pad_len), mode="constant", value=0)
 
-        context_layer = DeviceOperator.npu_flash_attention(
+        context_layer, _ = torch_npu.npu_fused_infer_attention_score(
             query=q,
             key=k,
             value=v,
-            seq_lens_cpu=seq_lens_cpu,
-            head_num=self.num_heads,
-            scale_value=self.scale_value,
-            num_kv_heads=self.num_kv_heads,
+            atten_mask=attn_mask,
+            block_table=block_table,
+            input_layout=input_layout,
+            block_size=block_size,
+            actual_seq_lengths=actual_seq_lengths,
+            actual_seq_lengths_kv=actual_seq_lengths_kv,
+            num_key_value_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            scale=self.scale_value,
+            sparse_mode=sparse_mode,
+            pre_tokens=pre_tokens,
+            next_tokens=next_tokens,
         )
 
         if self.enable_pad:
-            context_layer = context_layer[..., :origin_shape]
+            context_layer = context_layer[..., :origin_head_dim]
 
         if is_reshaped:
             context_layer = einops.rearrange(context_layer, "(b s) h d -> b s h d", b=bsz).contiguous()


### PR DESCRIPTION
Refactor AscendMMEncoderAttention for improved sequence length handling

- Introduced helper methods for computing actual sequence lengths and building inputs for dense ViT.
- Updated forward methods to utilize new helper functions, enhancing clarity and performance.
- Removed redundant CPU caching logic for sequence lengths, simplifying the codebase.
- Integrated `torch_npu` for attention score computation, aligning with NPU optimizations.

These changes streamline the attention mechanism for the Ascend platform, improving efficiency and maintainability.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8